### PR TITLE
Mirror of microsoft onnxruntime#3001

### DIFF
--- a/tools/ci_build/github/azure-pipelines/nuget/templates/gpu.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/gpu.yml
@@ -30,7 +30,7 @@ jobs:
     AgentPool : 'Win-GPU-2019'
     ArtifactName: drop-nuget-dml
     JobName: 'Windows_CI_GPU_DML_Dev'
-    BuildCommand: --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --use_featurizers --enable_onnx_tests --use_telemetry --use_dml --cmake_generator "Visual Studio 16 2019"
+    BuildCommand: --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --use_featurizers --enable_onnx_tests --use_telemetry --cmake_generator "Visual Studio 16 2019"
     BuildArch: 'x64'
     msbuildArchitecture: 'amd64'
     EnvSetupScript: 'setup_env.bat'    


### PR DESCRIPTION
Mirror of microsoft onnxruntime#3001
Test failures in creating the DML provider are causing failures in this pipeline. 
This was introduced with WindowsAI merged into to master.

Removing the usage of use_dml in this pipeline to unblock the build here. Need to investigate and root cause the test failures in dml before re-enabling.
