### PR TITLE
Mirror of microsoft onnxruntime#3003

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -224,7 +224,7 @@ setup(
     py_modules=python_modules_list,
     install_requires=[
         'onnx>=1.6.0,<1.7.0',
-        'numpy>=1.18.0'
+        'numpy>=1.18.0,<2.0.0'
     ],
     entry_points= {
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -223,7 +223,7 @@ setup(
     },
     py_modules=python_modules_list,
     install_requires=[
-        'onnx>=1.2.3',
+        'onnx>=1.6.0,<1.7.0',
         'numpy>=1.18.0'
     ],
     entry_points= {

--- a/setup.py
+++ b/setup.py
@@ -223,7 +223,7 @@ setup(
     },
     py_modules=python_modules_list,
     install_requires=[
-        'onnx>=1.6.0,<1.7.0',
+        'onnx>=1.2.3,<1.7.0',
         'numpy>=1.18.0,<2.0.0'
     ],
     entry_points= {


### PR DESCRIPTION
Mirror of microsoft onnxruntime#3003
**Description**: 

Pin onnx version so that onnxruntime won't accidentally get broken because of a new ONNX release

**Motivation and Context**
- Why is this change required? What problem does it solve?

ONNX defines some python interface(base classes)
We implemented these inferface.
However, nobody guarantee the inferface won't have backward incompatible changes in ONNX.

- If it fixes an open issue, please link to the issue here.

