### PR TITLE
Mirror of microsoft onnxruntime#3010

### DIFF
--- a/onnxruntime/test/ir/onnx_model_test.cc
+++ b/onnxruntime/test/ir/onnx_model_test.cc
@@ -8,6 +8,7 @@
 #include "core/graph/model.h"
 #include "core/graph/op.h"
 #include "core/session/onnxruntime_c_api.h"
+#include "test/providers/provider_test_utils.h"  //For ASSERT_STATUS_OK
 #include "test/test_environment.h"
 #include "gtest/gtest.h"
 
@@ -15,6 +16,14 @@ using namespace onnxruntime;
 using namespace ONNX_NAMESPACE;
 namespace onnxruntime {
 namespace test {
+class ONNXModelsTest : public ::testing::Test {
+ protected:
+  ONNXModelsTest() {
+    logger_ = DefaultLoggingManager().CreateLogger("GraphTest");
+  }
+
+  std::unique_ptr<logging::Logger> logger_;
+};
 #ifdef ORT_RUN_EXTERNAL_ONNX_TESTS
 // Tests that Resolve() properly clears the state of topological sorted nodes,
 // inputs, outputs and valueInfo.
@@ -29,7 +38,7 @@ static void TestResolve(onnxruntime::Graph& graph) {
   // Touch the graph to force Resolve() to recompute.
   graph.SetGraphResolveNeeded();
   graph.SetGraphProtoSyncNeeded();
-  EXPECT_TRUE(graph.Resolve().IsOK());
+  ASSERT_STATUS_OK(graph.Resolve());
 
   GraphViewer graph_viewer_2(graph);
   auto& nodes_after = graph_viewer_2.GetNodesInTopologicalOrder();
@@ -46,39 +55,53 @@ static void TestResolve(onnxruntime::Graph& graph) {
   EXPECT_EQ(value_info_before, value_info_after);
 }
 
-TEST(ONNXModelsTest, squeeze_net) {
+TEST_F(ONNXModelsTest, squeeze_net) {
   // NOTE: this requires the current directory to be where onnxruntime_ir_UT.exe is located
   std::shared_ptr<Model> model;
-  ASSERT_TRUE(Model::Load(ORT_TSTR("../models/opset8/test_squeezenet/model.onnx"), model, nullptr, DefaultLoggingManager().DefaultLogger()).IsOK());
+  ASSERT_STATUS_OK(Model::Load(ORT_TSTR("../models/opset8/test_squeezenet/model.onnx"), model, nullptr, *logger_));
   TestResolve(model->MainGraph());
 }
 #endif
 
-TEST(ONNXModelsTest, non_existing_model) {
+TEST_F(ONNXModelsTest, non_existing_model) {
   // NOTE: this requires the current directory to be where onnxruntime_ir_UT.exe is located
   std::shared_ptr<Model> model;
-  common::Status st = Model::Load(ORT_TSTR("./testdata/non_existing_model_XXXXXX/model.onnx"), model, nullptr,
-                                  DefaultLoggingManager().DefaultLogger());
+  common::Status st = Model::Load(ORT_TSTR("./testdata/non_existing_model_XXXXXX/model.onnx"), model, nullptr, *logger_);
   ASSERT_FALSE(st.IsOK());
   ASSERT_EQ(st.Code(), common::NO_SUCHFILE);
 }
 
-TEST(ONNXModelsTest, future_opset) {
+TEST_F(ONNXModelsTest, future_opset) {
   // NOTE: this requires the current directory to be where onnxruntime_ir_UT.exe is located
   std::shared_ptr<Model> model;
-  common::Status st = Model::Load(ORT_TSTR("./testdata/add_opset_314159.onnx"), model, nullptr,
-                                DefaultLoggingManager().DefaultLogger());
+  common::Status st = Model::Load(ORT_TSTR("./testdata/add_opset_314159.onnx"), model, nullptr, *logger_);
   ASSERT_FALSE(st.IsOK());
   ASSERT_EQ(st.Code(), common::INVALID_GRAPH);
 }
 
+class ONNXModelsTest1 : public ::testing::TestWithParam<const ORTCHAR_T*> {
+  // You can implement all the usual fixture class members here.
+  // To access the test parameter, call GetParam() from class
+  // TestWithParam<T>.
+ public:
+  ONNXModelsTest1() {
+    logger_ = DefaultLoggingManager().CreateLogger("GraphTest");
+  }
+
+  std::unique_ptr<logging::Logger> logger_;
+  std::basic_string<ORTCHAR_T> GetModelFileName() const {
+    std::basic_ostringstream<ORTCHAR_T> oss;
+    oss << ORT_TSTR("../models/opset7/test_") << GetParam() << ORT_TSTR("/model.onnx");
+    return oss.str();
+  }
+};
 #ifdef ORT_RUN_EXTERNAL_ONNX_TESTS
-TEST(ONNXModelsTest1, bvlc_alexnet_1) {
+TEST_F(ONNXModelsTest, bvlc_alexnet_1) {
   using ::google::protobuf::io::CodedInputStream;
   using ::google::protobuf::io::FileInputStream;
   using ::google::protobuf::io::ZeroCopyInputStream;
   int fd;
-  ASSERT_TRUE(Env::Default().FileOpenRd(ORT_TSTR("../models/opset8/test_bvlc_alexnet/model.onnx"), fd).IsOK());
+  ASSERT_STATUS_OK(Env::Default().FileOpenRd(ORT_TSTR("../models/opset8/test_bvlc_alexnet/model.onnx"), fd));
   ASSERT_TRUE(fd > 0);
   std::unique_ptr<ZeroCopyInputStream> raw_input(new FileInputStream(fd));
   std::unique_ptr<CodedInputStream> coded_input(new CodedInputStream(raw_input.get()));
@@ -89,12 +112,11 @@ TEST(ONNXModelsTest1, bvlc_alexnet_1) {
   coded_input.reset();
   raw_input.reset();
   EXPECT_TRUE(result);
-  ASSERT_TRUE(Env::Default().FileClose(fd).IsOK());
+  ASSERT_STATUS_OK(Env::Default().FileClose(fd));
 
   std::shared_ptr<Model> model;
-  ASSERT_TRUE(Model::Load(ORT_TSTR("../models/opset8/test_bvlc_alexnet/model.onnx"), model, nullptr,
-                          DefaultLoggingManager().DefaultLogger())
-                  .IsOK());
+  ASSERT_STATUS_OK(Model::Load(ORT_TSTR("../models/opset8/test_bvlc_alexnet/model.onnx"), model, nullptr,
+                               *logger_));
 
   // Check the graph input/output/value_info should have the same size as specified in the model file.
   EXPECT_EQ(static_cast<size_t>(model_proto.graph().value_info_size()), model->MainGraph().GetValueInfo().size());
@@ -103,33 +125,19 @@ TEST(ONNXModelsTest1, bvlc_alexnet_1) {
   TestResolve(model->MainGraph());
 }
 
-class ONNXModelsTest : public ::testing::TestWithParam<const ORTCHAR_T*> {
-  // You can implement all the usual fixture class members here.
-  // To access the test parameter, call GetParam() from class
-  // TestWithParam<T>.
- public:
-  std::basic_string<ORTCHAR_T> GetModelFileName() const {
-    std::basic_ostringstream<ORTCHAR_T> oss;
-    oss << ORT_TSTR("../models/opset7/test_") << GetParam() << ORT_TSTR("/model.onnx");
-    return oss.str();
-  }
-};
-
-TEST_P(ONNXModelsTest, LoadFromFile) {
+TEST_P(ONNXModelsTest1, LoadFromFile) {
   std::shared_ptr<Model> model;
-  ASSERT_TRUE(Model::Load(GetModelFileName(), model, nullptr,
-                          DefaultLoggingManager().DefaultLogger())
-                  .IsOK());
+  ASSERT_STATUS_OK(Model::Load(GetModelFileName(), model, nullptr,
+                               *logger_));
   TestResolve(model->MainGraph());
 }
 
-TEST_P(ONNXModelsTest, LoadFromProtobuf) {
+TEST_P(ONNXModelsTest1, LoadFromProtobuf) {
   using ::google::protobuf::io::CodedInputStream;
   using ::google::protobuf::io::FileInputStream;
   using ::google::protobuf::io::ZeroCopyInputStream;
   int fd;
-  auto st = Env::Default().FileOpenRd(GetModelFileName(), fd);
-  ASSERT_TRUE(st.IsOK()) << st.ErrorMessage();
+  ASSERT_STATUS_OK(Env::Default().FileOpenRd(GetModelFileName(), fd));
   ASSERT_TRUE(fd > 0);
   std::unique_ptr<ZeroCopyInputStream> raw_input(new FileInputStream(fd));
   std::unique_ptr<CodedInputStream> coded_input(new CodedInputStream(raw_input.get()));
@@ -139,21 +147,20 @@ TEST_P(ONNXModelsTest, LoadFromProtobuf) {
   coded_input.reset();
   raw_input.reset();
   ASSERT_TRUE(result);
-  ASSERT_TRUE(Env::Default().FileClose(fd).IsOK());
+  ASSERT_STATUS_OK(Env::Default().FileClose(fd));
   std::shared_ptr<Model> model;
-  ASSERT_TRUE(Model::Load(std::move(model_proto), model, nullptr,
-                          DefaultLoggingManager().DefaultLogger())
-                  .IsOK());
+  ASSERT_STATUS_OK(Model::Load(std::move(model_proto), model, nullptr,
+                               *logger_));
   TestResolve(model->MainGraph());
 }
 
 #ifndef DISABLE_CONTRIB_OPS
 INSTANTIATE_TEST_CASE_P(ONNXModelsTests,
-                        ONNXModelsTest,
+                        ONNXModelsTest1,
                         ::testing::Values(ORT_TSTR("bvlc_alexnet"), ORT_TSTR("bvlc_googlenet"), ORT_TSTR("bvlc_reference_caffenet"), ORT_TSTR("bvlc_reference_rcnn_ilsvrc13"), ORT_TSTR("densenet121"), ORT_TSTR("emotion_ferplus"), ORT_TSTR("inception_v1"), ORT_TSTR("inception_v2"), ORT_TSTR("mnist"), ORT_TSTR("resnet50"), ORT_TSTR("shufflenet"), ORT_TSTR("squeezenet"), ORT_TSTR("tiny_yolov2"), ORT_TSTR("vgg19"), ORT_TSTR("zfnet512")));
 #else
 INSTANTIATE_TEST_CASE_P(ONNXModelsTests,
-                        ONNXModelsTest,
+                        ONNXModelsTest1,
                         ::testing::Values(ORT_TSTR("bvlc_alexnet"), ORT_TSTR("bvlc_googlenet"), ORT_TSTR("bvlc_reference_caffenet"), ORT_TSTR("bvlc_reference_rcnn_ilsvrc13"), ORT_TSTR("densenet121"), ORT_TSTR("emotion_ferplus"), ORT_TSTR("inception_v1"), ORT_TSTR("inception_v2"), ORT_TSTR("mnist"), ORT_TSTR("resnet50"), ORT_TSTR("shufflenet"), ORT_TSTR("squeezenet"), ORT_TSTR("vgg19"), ORT_TSTR("zfnet512")));
 #endif
 
@@ -163,27 +170,22 @@ INSTANTIATE_TEST_CASE_P(ONNXModelsTests,
 // a NodeArg should be created for all initializers in this case.
 // the test model contains initializers that are used as implicit inputs in a subgraph, and the NodeArg is required
 // for Graph::Resolve to succeed when processing the subgraph.
-TEST(ONNXModelsTest, TestIRv4NonInputInitializers) {
+TEST_F(ONNXModelsTest, TestIRv4NonInputInitializers) {
   std::shared_ptr<Model> model;
-  ASSERT_TRUE(Model::Load(ORT_TSTR("testdata/subgraph_implicit_input_from_initializer.onnx"), model, nullptr,
-                          DefaultLoggingManager().DefaultLogger())
-                  .IsOK());
-  EXPECT_TRUE(model->MainGraph().Resolve().IsOK());
+  ASSERT_STATUS_OK(Model::Load(ORT_TSTR("testdata/subgraph_implicit_input_from_initializer.onnx"), model, nullptr,
+                               *logger_));
+  ASSERT_STATUS_OK(model->MainGraph().Resolve());
 }
 
 // test a model that has an op with a FunctionBody and one of the nodes within the FunctionBody has a subgraph in it.
 // The test model has is an opset-11 op with a 'Range' node.
 // 'Range' has a FunctionBody and has a 'Loop' node with a subgraph.
 // Graph::Resolve to succeed when processing the subgraph pertaining to the overall FunctionBody.
-TEST(ONNXModelsTest, TestModelsWithAnOpContainingAFunctionBody) {
+TEST_F(ONNXModelsTest, TestModelsWithAnOpContainingAFunctionBody) {
   std::shared_ptr<Model> model;
-
-  auto status = Model::Load(ORT_TSTR("testdata/model_containing_op_with_function_body.onnx"), model, nullptr,
-                            DefaultLoggingManager().DefaultLogger());
-  EXPECT_TRUE(status.IsOK()) << status;
-
-  status = model->MainGraph().Resolve();
-  EXPECT_TRUE(status.IsOK()) << status;
+  ASSERT_STATUS_OK(Model::Load(ORT_TSTR("testdata/model_containing_op_with_function_body.onnx"), model, nullptr,
+                               *logger_));
+  ASSERT_STATUS_OK(model->MainGraph().Resolve());
 }
 
 }  // namespace test

--- a/onnxruntime/test/ir/op_test.cc
+++ b/onnxruntime/test/ir/op_test.cc
@@ -104,91 +104,15 @@ TEST(OpRegistrationTest, OpRegTest) {
   EXPECT_EQ(**op_schema->outputs()[0].GetTypes().find(Utils::DataTypeUtils::ToType("tensor(int32)")), "tensor(int32)");
 }
 
-ONNX_NAMESPACE::OpSchema CreateTestSchema(const char* name, const char* domain, int sinceVersion) {
+static ONNX_NAMESPACE::OpSchema CreateTestSchema(const char* name, const char* domain, int sinceVersion) {
   return ONNX_NAMESPACE::OpSchema().SetName(name).SinceVersion(sinceVersion).SetDomain(domain).Output(0, "output_1", "docstr for output", "tensor(int32)");
 }
 
-TEST(OpRegistrationTest, OpsetRegTest) {
-  std::shared_ptr<onnxruntime::OnnxRuntimeOpSchemaRegistry> registry = std::make_shared<OnnxRuntimeOpSchemaRegistry>();
-
-  // Register op-set version 1 with baseline version 0
+TEST(OnnxRuntimeOpSchemaRegistry, OpsetRegTest_WrongDomain) {
   std::vector<ONNX_NAMESPACE::OpSchema> schema = {CreateTestSchema("Op1", "Domain1", 1), CreateTestSchema("Op2", "Domain1", 1)};
-  EXPECT_TRUE(registry->RegisterOpSet(schema, "Domain1", 0, 1).IsOK());
-
-  // Get the schema
-  EXPECT_TRUE(registry->GetSchema("Op1", 1, "Domain1")->Name() == "Op1");
-  EXPECT_TRUE(registry->GetSchema("Op2", 1, "Domain1")->Name() == "Op2");
-
-  // Getting schema with wrong name, domain, and version will fail
-  EXPECT_TRUE(registry->GetSchema("Op1", 1, "WrongDomain") == nullptr);
-  EXPECT_TRUE(registry->GetSchema("WrongOp", 1, "Domain1") == nullptr);
-  EXPECT_TRUE(registry->GetSchema("Op1", 2, "Domain1") == nullptr);
-  EXPECT_TRUE(registry->GetSchema("Op1", 0, "Domain1") == nullptr);
-
-  // Registering a new op-set in the same domain will fail.  This (currently) requires the caller to
-  // use multiple registry instances and a registry manager.
-  std::vector<ONNX_NAMESPACE::OpSchema> schemaV2 = {CreateTestSchema("Op1", "Domain1", 2)};
-  EXPECT_FALSE(registry->RegisterOpSet(schemaV2, "Domain1", 1, 2).IsOK());
-
   // Registering an op-set with schema in a different domain than the op-set will fail
   std::shared_ptr<onnxruntime::OnnxRuntimeOpSchemaRegistry> temp_reg = std::make_shared<OnnxRuntimeOpSchemaRegistry>();
-  EXPECT_FALSE(temp_reg->RegisterOpSet(schema, "WrongDomain", 0, 1).IsOK());
-
-  // Registering a second op-set in a different domain should succeed
-  std::vector<ONNX_NAMESPACE::OpSchema> schemaDomain2 = {CreateTestSchema("Op2", "Domain2", 1)};
-  EXPECT_TRUE(registry->RegisterOpSet(schemaDomain2, "Domain2", 0, 1).IsOK());
-  EXPECT_TRUE(registry->GetSchema("Op1", 1, "Domain1")->Name() == "Op1");
-  EXPECT_TRUE(registry->GetSchema("Op2", 1, "Domain2")->Name() == "Op2");
-
-  // Overriding existing op-set schema will fail
-  std::vector<ONNX_NAMESPACE::OpSchema> schemaOverride = {CreateTestSchema("Op1", "Domain1", 1)};
-  EXPECT_FALSE(registry->RegisterOpSet(schema, "Domain1", 0, 1).IsOK());
-
-  // Create a second registry, combined with the first through a manager
-  std::shared_ptr<onnxruntime::OnnxRuntimeOpSchemaRegistry> registry2 = std::make_shared<OnnxRuntimeOpSchemaRegistry>();
-  SchemaRegistryManager manager;
-  manager.RegisterRegistry(registry);
-  manager.RegisterRegistry(registry2);
-
-  // Register the second version of the same op-set on the second registry, overriding one operator
-  EXPECT_TRUE(registry2->RegisterOpSet(schemaV2, "Domain1", 1, 2).IsOK());
-  EXPECT_TRUE(manager.GetSchema("Op1", 1, "Domain1")->since_version() == 1);
-  EXPECT_TRUE(manager.GetSchema("Op1", 2, "Domain1")->since_version() == 2);
-  EXPECT_TRUE(manager.GetSchema("Op2", 1, "Domain1")->since_version() == 1);
-
-  // Op2 is provided only in opset v1, and in the first registry.  The absence of Op2 in the second
-  // registry will trigger the first registry to be queried using V1 rather than V2 here.
-  EXPECT_TRUE(manager.GetSchema("Op2", 2, "Domain1")->since_version() == 1);
-
-  // Add a new operator set which is verion 5, with a baseline of version 4, meaning that
-  // there is a gap at version 3.
-  std::shared_ptr<onnxruntime::OnnxRuntimeOpSchemaRegistry> registryV5 = std::make_shared<OnnxRuntimeOpSchemaRegistry>();
-  manager.RegisterRegistry(registryV5);
-  std::vector<ONNX_NAMESPACE::OpSchema> schemaV5 = {
-      CreateTestSchema("Op3", "Domain1", 4),
-      CreateTestSchema("Op4", "Domain1", 5),
-      CreateTestSchema("Op5", "Domain1", 1)};
-  EXPECT_TRUE(registryV5->RegisterOpSet(schemaV5, "Domain1", 4, 5).IsOK());
-
-  // Query the new version 5 op.  This will be missing for earlier versions
-  EXPECT_TRUE(manager.GetSchema("Op4", 5, "Domain1")->since_version() == 5);
-  EXPECT_TRUE(manager.GetSchema("Op4", 4, "Domain1") == nullptr);
-
-  // The only schema with SinceVersion < 3 which can be  queried as version 5 are those which are registered on
-  // the v5 registry itself.  Those schema may be queried for any version between their sinceVersion and the
-  // opset's version.
-  EXPECT_TRUE(manager.GetSchema("Op1", 5, "Domain1") == nullptr);
-  EXPECT_TRUE(manager.GetSchema("Op3", 5, "Domain1")->since_version() == 4);
-  EXPECT_TRUE(manager.GetSchema("Op3", 4, "Domain1")->since_version() == 4);
-
-  // Note that "Op5" has SinceVersion equal to 1, but a V1 operator set was already registered
-  // without this operator.  This would normally be invalid, and the registry with the missing
-  // operator could trigger the operator lookup to fail.  Version 1 is a special case to allow
-  // for experimental operators, and is accomplished by not reducing the targetted version to
-  // zero in OnnxRuntimeOpSchemaRegistry::GetSchemaAndHistory.
-  // TODO - Consider making the registration algorithm robust to this invalid usage in general
-  EXPECT_TRUE(manager.GetSchema("Op5", 5, "Domain1")->since_version() == 1);
-  EXPECT_TRUE(manager.GetSchema("Op5", 1, "Domain1")->since_version() == 1);
+  ASSERT_FALSE(temp_reg->RegisterOpSet(schema, "WrongDomain", 0, 1).IsOK());
 }
 
 TEST(OpRegistrationTest, TypeConstraintTest) {

--- a/onnxruntime/test/ir/schema_registry_manager_test.cc
+++ b/onnxruntime/test/ir/schema_registry_manager_test.cc
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <core/graph/schema_registry.h>
+#include "test/providers/provider_test_utils.h" //For ASSERT_STATUS_OK
+#include "gtest/gtest.h"
+
+ONNX_NAMESPACE::OpSchema CreateTestSchema(const char* name, const char* domain, int sinceVersion) {
+  return ONNX_NAMESPACE::OpSchema().SetName(name).SinceVersion(sinceVersion).SetDomain(domain).Output(0, "output_1", "docstr for output", "tensor(int32)");
+}
+
+using namespace onnxruntime;
+TEST(SchemaRegistryManager, search_onnx_op) {
+  SchemaRegistryManager manager;
+  ASSERT_NE(manager.GetSchema("Gemm", 10, ""), nullptr);
+}
+
+TEST(SchemaRegistryManager, search_memcpy_op) {
+  SchemaRegistryManager manager;
+  ASSERT_NE(manager.GetSchema("MemcpyToHost", 1, ""), nullptr);
+}
+
+TEST(SchemaRegistryManager, search_memcpy_op_wrong_version) {
+  SchemaRegistryManager manager;
+  ASSERT_EQ(manager.GetSchema("MemcpyToHost", 9999, ""), nullptr);
+}
+
+TEST(SchemaRegistryManager, search_onnxml_op) {
+  SchemaRegistryManager manager;
+  ASSERT_NE(manager.GetSchema("ArrayFeatureExtractor", 1, "ai.onnx.ml"), nullptr);
+}
+
+TEST(SchemaRegistryManager, search_onnxml_op_wrong_opset_version) {
+  SchemaRegistryManager manager;
+  ASSERT_EQ(manager.GetSchema("ArrayFeatureExtractor", 99, "ai.onnx.ml"), nullptr);
+}
+
+TEST(SchemaRegistryManager, search_custom_op_wrong_opset_version) {
+  SchemaRegistryManager manager;
+  std::shared_ptr<onnxruntime::OnnxRuntimeOpSchemaRegistry> registry = std::make_shared<OnnxRuntimeOpSchemaRegistry>();
+  std::vector<ONNX_NAMESPACE::OpSchema> schema = {CreateTestSchema("Op1", "Domain1", 1)};
+  ASSERT_EQ(manager.GetSchema("Op1", 99, "Domain1"), nullptr);
+}
+
+TEST(SchemaRegistryManager, OpsetRegTest) {
+  std::shared_ptr<onnxruntime::OnnxRuntimeOpSchemaRegistry> registry = std::make_shared<OnnxRuntimeOpSchemaRegistry>();
+
+  // Register op-set version 1 with baseline version 0
+  std::vector<ONNX_NAMESPACE::OpSchema> schema = {CreateTestSchema("Op1", "Domain1", 1), CreateTestSchema("Op2", "Domain1", 1)};
+  ASSERT_STATUS_OK(registry->RegisterOpSet(schema, "Domain1", 0, 1));
+
+  // Get the schema
+  ASSERT_TRUE(registry->GetSchema("Op1", 1, "Domain1")->Name() == "Op1");
+  ASSERT_TRUE(registry->GetSchema("Op2", 1, "Domain1")->Name() == "Op2");
+
+  // Getting schema with wrong name, domain, and version will fail
+  ASSERT_TRUE(registry->GetSchema("Op1", 1, "WrongDomain") == nullptr);
+  ASSERT_TRUE(registry->GetSchema("WrongOp", 1, "Domain1") == nullptr);
+  // Fail because this registry doesn't have information for opset2.
+  ASSERT_TRUE(registry->GetSchema("Op1", 2, "Domain1") == nullptr);
+  ASSERT_TRUE(registry->GetSchema("Op1", 0, "Domain1") == nullptr);
+
+  // Registering a new op-set in the same domain will fail.  This (currently) requires the caller to
+  // use multiple registry instances and a registry manager.
+  std::vector<ONNX_NAMESPACE::OpSchema> schemaV2 = {CreateTestSchema("Op1", "Domain1", 2)};
+  ASSERT_FALSE(registry->RegisterOpSet(schemaV2, "Domain1", 1, 2).IsOK());
+
+  // Registering a second op-set in a different domain should succeed
+  std::vector<ONNX_NAMESPACE::OpSchema> schemaDomain2 = {CreateTestSchema("Op2", "Domain2", 1)};
+  ASSERT_STATUS_OK(registry->RegisterOpSet(schemaDomain2, "Domain2", 0, 1));
+  ASSERT_TRUE(registry->GetSchema("Op1", 1, "Domain1")->Name() == "Op1");
+  ASSERT_TRUE(registry->GetSchema("Op2", 1, "Domain2")->Name() == "Op2");
+
+  // Overriding existing op-set schema will fail
+  std::vector<ONNX_NAMESPACE::OpSchema> schemaOverride = {CreateTestSchema("Op1", "Domain1", 1)};
+  ASSERT_FALSE(registry->RegisterOpSet(schema, "Domain1", 0, 1).IsOK());
+
+  // Create a second registry, combined with the first through a manager
+  std::shared_ptr<onnxruntime::OnnxRuntimeOpSchemaRegistry> registry2 = std::make_shared<OnnxRuntimeOpSchemaRegistry>();
+  SchemaRegistryManager manager;
+  manager.RegisterRegistry(registry);
+  manager.RegisterRegistry(registry2);
+
+  // Register the second version of the same op-set on the second registry, overriding one operator
+  ASSERT_STATUS_OK(registry2->RegisterOpSet(schemaV2, "Domain1", 1, 2));
+  //Now the registry1 has: (op1,domain1,version1), (op2,domain1,version1), (op2,domain2,version1)
+  //registry2 has:(op1,domain1,version2)
+  ASSERT_TRUE(registry2->GetSchema("Op1", 1, "Domain1") == nullptr);
+  ASSERT_TRUE(registry2->GetSchema("Op1", 2, "Domain1") != nullptr);
+  //Fail because this registery doesn't have the information of opset3
+  ASSERT_TRUE(registry2->GetSchema("Op1", 3, "Domain1") == nullptr);
+
+  std::shared_ptr<onnxruntime::OnnxRuntimeOpSchemaRegistry> registry3 = std::make_shared<OnnxRuntimeOpSchemaRegistry>();
+  ASSERT_STATUS_OK(registry3->RegisterOpSet(schemaV2, "Domain1", 1, 3));
+  //Now it's ok.
+  ASSERT_TRUE(registry3->GetSchema("Op1", 3, "Domain1") != nullptr);
+
+  ASSERT_TRUE(manager.GetSchema("Op1", 1, "Domain1")->since_version() == 1);
+  ASSERT_TRUE(manager.GetSchema("Op1", 2, "Domain1")->since_version() == 2);
+  ASSERT_TRUE(manager.GetSchema("Op2", 1, "Domain1")->since_version() == 1);
+  ASSERT_TRUE(manager.GetSchema("Op2", 2, "Domain1")->since_version() == 1);
+
+  // Add a new operator set which is verion 5, with a baseline of version 4, meaning that
+  // there is a gap at version 3.
+  std::shared_ptr<onnxruntime::OnnxRuntimeOpSchemaRegistry> registryV5 = std::make_shared<OnnxRuntimeOpSchemaRegistry>();
+  manager.RegisterRegistry(registryV5);
+  std::vector<ONNX_NAMESPACE::OpSchema> schemaV5 = {
+      CreateTestSchema("Op3", "Domain1", 4),
+      CreateTestSchema("Op4", "Domain1", 5),
+      CreateTestSchema("Op5", "Domain1", 1)};
+  ASSERT_STATUS_OK(registryV5->RegisterOpSet(schemaV5, "Domain1", 4, 5));
+
+  // Query the new version 5 op.  This will be missing for earlier versions
+  ASSERT_TRUE(manager.GetSchema("Op4", 5, "Domain1")->since_version() == 5);
+  ASSERT_TRUE(manager.GetSchema("Op4", 4, "Domain1") == nullptr);
+
+  // The only schema with SinceVersion < 3 which can be  queried as version 5 are those which are registered on
+  // the v5 registry itself.  Those schema may be queried for any version between their sinceVersion and the
+  // opset's version.
+  ASSERT_TRUE(manager.GetSchema("Op1", 5, "Domain1") == nullptr);
+  ASSERT_TRUE(manager.GetSchema("Op3", 5, "Domain1")->since_version() == 4);
+  ASSERT_TRUE(manager.GetSchema("Op3", 4, "Domain1")->since_version() == 4);
+
+  // Note that "Op5" has SinceVersion equal to 1, but a V1 operator set was already registered
+  // without this operator.  This would normally be invalid, and the registry with the missing
+  // operator could trigger the operator lookup to fail.  Version 1 is a special case to allow
+  // for experimental operators, and is accomplished by not reducing the targetted version to
+  // zero in OnnxRuntimeOpSchemaRegistry::GetSchemaAndHistory.
+  // TODO - Consider making the registration algorithm robust to this invalid usage in general
+  ASSERT_TRUE(manager.GetSchema("Op5", 5, "Domain1")->since_version() == 1);
+  ASSERT_TRUE(manager.GetSchema("Op5", 1, "Domain1")->since_version() == 1);
+}

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -35,6 +35,9 @@ void TestReduceOp(const std::string& op,
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kCudaExecutionProvider, kTensorrtExecutionProvider});  //TensorRT: result differs
 }
 
+//TODO:investigate why it is so slow. It need 12 seconds on an Azure Standard F48s_v2 (48 vcpus, 96 GiB memory)
+// machine in RelWithDebInfo build mode, but only 2 seconds on my local dev machine(4 cores).
+#ifdef NDEBUG
 TEST(ReductionOpTest, ReductionVariationTest) {
   const std::vector<float>& input_data = testcases.input_data;
   const std::vector<int64_t>& input_dims = testcases.input_dims;
@@ -60,6 +63,7 @@ TEST(ReductionOpTest, ReductionVariationTest) {
     }
   }
 }
+#endif
 
 TEST(ReductionOpTest, ReduceL1_default_axes_keepdims) {
   OpTester test("ReduceL1");


### PR DESCRIPTION
Mirror of microsoft onnxruntime#3010
**Description**: 

1. Add test cases for the schema registry in onnxruntime_graph
2. Use ASSERT_STATUS_OK when appropriate

**Motivation and Context**
- Why is this change required? What problem does it solve?

Not required. But it makes better.

- If it fixes an open issue, please link to the issue here.

