### PR TITLE
Mirror of microsoft onnxruntime#3011

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -247,7 +247,7 @@
          "component": {
             "type": "git",
             "git": {
-               "commitHash": "fe1790ca0df67173702f70d5646b82f48f412b99",
+               "commitHash": "498de9f761bef56a032815ee44b6e6dbe0892cc4",
                "repositoryUrl": "https://github.com/protocolbuffers/protobuf.git"
             }
          }

--- a/cmake/patches/ngraph/ngraph_protobuf.patch
+++ b/cmake/patches/ngraph/ngraph_protobuf.patch
@@ -11,7 +11,7 @@ index 32217f5d6..d33e9c631 100644
  # This version of PROTOBUF is required by Microsoft ONNX Runtime.
  set(NGRAPH_PROTOBUF_GIT_REPO_URL "https://github.com/protocolbuffers/protobuf")
 -set(NGRAPH_PROTOBUF_GIT_TAG "v3.5.2")
-+set(NGRAPH_PROTOBUF_GIT_TAG "v3.11.2")
++set(NGRAPH_PROTOBUF_GIT_TAG "v3.11.3")
  
  if (WIN32)
      ExternalProject_Add(

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj
@@ -13,7 +13,7 @@
     <PackageName Condition="'$(PackageName)' == ''">Microsoft.ML.OnnxRuntime</PackageName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.11.2" />
+    <PackageReference Include="Google.Protobuf" Version="3.11.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/Microsoft.ML.OnnxRuntime.Tests.csproj
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/Microsoft.ML.OnnxRuntime.Tests.csproj
@@ -47,7 +47,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.Targets" Version="2.1.0"/>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2"/>
-    <PackageReference Include="Google.Protobuf" Version="3.11.2" />
+    <PackageReference Include="Google.Protobuf" Version="3.11.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />


### PR DESCRIPTION
Mirror of microsoft onnxruntime#3011
**Description**: 
Upgrade protobuf to 3.11.3 which is just a tiny patch release that contains a portability bug fix for Windows.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

