### PR TITLE
Mirror of microsoft onnxruntime#3012

### DIFF
--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -96,7 +96,7 @@ Model::Model(std::unique_ptr<ModelProto> model_proto, const IOnnxRuntimeOpSchema
   }
 
   if (!model_proto->has_ir_version() || model_proto->ir_version() > ONNX_NAMESPACE::Version::IR_VERSION) {
-      throw std::invalid_argument("Unknown model file format version.");
+    throw std::invalid_argument("Unknown model file format version.");
   }
 
   model_proto_ = std::move(model_proto);
@@ -394,14 +394,14 @@ Status Model::LoadFromBytes(int count, void* p_bytes, /*out*/ ONNX_NAMESPACE::Mo
 
 Status Model::LoadFromBytes(int count, void* p_bytes, /*out*/ std::shared_ptr<Model>& p_model,
                             const IOnnxRuntimeOpSchemaRegistryList* local_registries, const logging::Logger& logger) {
-  ModelProto model_proto;
+  auto model_proto = onnxruntime::make_unique<ModelProto>();
 
-  auto status = LoadFromBytes(count, p_bytes, model_proto);
+  auto status = LoadFromBytes(count, p_bytes, *model_proto);
   if (!status.IsOK()) {
     return status;
   }
 
-  p_model = std::make_shared<Model>(model_proto, local_registries, logger);
+  p_model = std::make_shared<Model>(std::move(model_proto), local_registries, logger);
 
   ORT_RETURN_IF_ERROR(p_model->MainGraph().Resolve(true));
 
@@ -441,11 +441,11 @@ Status Model::Load(int fd, ONNX_NAMESPACE::ModelProto& model_proto) {
 
 Status Model::Load(int fd, std::shared_ptr<Model>& p_model, const IOnnxRuntimeOpSchemaRegistryList* local_registries,
                    const logging::Logger& logger) {
-  ModelProto model_proto;
+  auto model_proto = onnxruntime::make_unique<ModelProto>();
 
-  ORT_RETURN_IF_ERROR(Load(fd, model_proto));
+  ORT_RETURN_IF_ERROR(Load(fd, *model_proto));
 
-  p_model = std::make_shared<Model>(model_proto, local_registries, logger);
+  p_model = std::make_shared<Model>(std::move(model_proto), local_registries, logger);
 
   ORT_RETURN_IF_ERROR(p_model->MainGraph().Resolve(true));
 

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -373,7 +373,7 @@ common::Status InferenceSession::Load(std::function<common::Status(std::shared_p
     is_model_loaded_ = true;
 
     // model_proto_ should either - 1) always have been a nullptr if the ModelProto was never parsed in the ctor (or)
-    // 2) should have become a nullptr by the passing on the ownership of the ModelProto resource it was pointing to,
+    // 2) should have become a nullptr by passing on the ownership of the ModelProto resource it was pointing to,
     // to the Model instance
     ORT_ENFORCE(model_proto_ == nullptr, "Failed to clear up model_proto_ in Inference Session");
 

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -497,7 +497,7 @@ common::Status InferenceSession::Load(std::istream& model_istream) {
                     "Failed to load model because protobuf parsing failed.");
     }
 #ifdef ENABLE_LANGUAGE_INTEROP_OPS
-    LoadInterOp(model_proto, interop_domains_, [&](const char* msg) { LOGS(*session_logger_, WARNING) << msg; });
+    LoadInterOp(*model_proto, interop_domains_, [&](const char* msg) { LOGS(*session_logger_, WARNING) << msg; });
     for (const auto& domain : interop_domains_) {
       AddCustomOpDomains({domain.get()});
     }

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -552,7 +552,7 @@ common::Status InferenceSession::Load() {
       AddCustomOpDomains({domain.get()});
     }
 #endif
-    // Pass on ownership of the extracted ModelProto to the Model instance (its job here is done by this stage)
+    // Pass on ownership of the parsed ModelProto to the Model instance (its job here is done by this stage)
     return Model::Load(std::move(this->model_proto_), model, HasLocalSchema() ? &custom_schema_registries_ : nullptr,
                        *session_logger_);
   };

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -373,7 +373,8 @@ common::Status InferenceSession::Load(std::function<common::Status(std::shared_p
     is_model_loaded_ = true;
 
     // model_proto_ should either - 1) always have been a nullptr if the ModelProto was never parsed in the ctor (or)
-    // 2) should have become a nullptr by the passing on theownership of the ModelProto resource it was pointing to, to the Model instance
+    // 2) should have become a nullptr by the passing on theownership of the ModelProto resource it was pointing to,
+    // to the Model instance
     ORT_ENFORCE(model_proto_ == nullptr, "Failed to clear up model_proto_ in Inference Session");
 
     telemetry_.event_name_ = event_name;

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -373,7 +373,7 @@ common::Status InferenceSession::Load(std::function<common::Status(std::shared_p
     is_model_loaded_ = true;
 
     // model_proto_ should either - 1) always have been a nullptr if the ModelProto was never parsed in the ctor (or)
-    // 2) should have become a nullptr by the passing on theownership of the ModelProto resource it was pointing to,
+    // 2) should have become a nullptr by the passing on the ownership of the ModelProto resource it was pointing to,
     // to the Model instance
     ORT_ENFORCE(model_proto_ == nullptr, "Failed to clear up model_proto_ in Inference Session");
 


### PR DESCRIPTION
Mirror of microsoft onnxruntime#3012
**Description**: Fixing some instances wherein unnecessary copies were being made of ModelProto instances

**Motivation and Context**
Reduce peak memory usage footprint at model load time
